### PR TITLE
Release v0.1.2

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,8 +23,8 @@ copyright = "2022, J Tosovic"
 author = "Jelena Tosovic, Domagoj Fijan, Marko Jukic, Urban Bren"
 
 # The full version, including alpha/beta/rc tags
-version = "0.1.1"
-release = "0.1.1"
+version = "0.1.2"
+release = "0.1.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except:
 
 setup(
     name="ConservedWaterSearch",
-    version="0.1.1",
+    version="0.1.2",
     author="Domagoj Fijan, Jelena Tosovic, Marko Jukic, Urban Bren",
     author_email="jecat_90@live.com",
     description=short_description[0],


### PR DESCRIPTION
Release v0.1.2 - 2/17/2023
=================

- fixed a bug in pymol visualization when no output file was specified
- fixed wrong logic in pymol visualization when aligned reference is specified
- added a better warning when mac OS is used with pymol visualization
- if pymol visualization on mac OS is used without output file specified, we still save the session to a file instead of failing
- updates to docs for pymol visualization