### PR TITLE
Align with NEP29

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        python-version: ["3.8","3.9","3.10","3.11"]
+        python-version: ["3.9","3.10","3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["dependencies"]
 
 [project.urls]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
-numpy>=1.21
+numpy>=1.22
 scikit-learn>=1.3


### PR DESCRIPTION
According to NEP29 python 3.8 should be dropped alongside with numpy 1.21. CI needs to be updated as well to reflect this.