### PR TITLE
Release v0.2.0

### DIFF
--- a/ConservedWaterSearch/utils.py
+++ b/ConservedWaterSearch/utils.py
@@ -170,6 +170,12 @@ def visualise_pymol(
             crystal waters shall be selected. Defaults to 10.0.
         density_map (str | None, optional): Water density map to add to
             visualisation session (usually .dx file). Defaults to None.
+        lunch_pymol (bool, optional): If `True` pymol will be lunched
+            in interactive mode. If `False` pymol will be imported
+            without lunching. Defaults to True.
+        reinitialize (bool, optional): If `True` pymol will be
+            reinitialized (defaults restored and objects cleaned).
+            Defaults to True.
 
     Example::
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,8 +23,8 @@ copyright = "2022, J Tosovic"
 author = "Jelena Tosovic, Domagoj Fijan, Marko Jukic, Urban Bren"
 
 # The full version, including alpha/beta/rc tags
-version = "0.1.2"
-release = "0.1.2"
+version = "0.2.0"
+release = "0.2.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ConservedWaterSearch"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     { name = "Domagoj Fijan" },
     { name = "Jelena Tosovic", email = "jecat_90@live.com" },


### PR DESCRIPTION
Release v0.2.0 - 9/5/2023
=================

- Dropped support for python 3.8
- Switch to sklearn HDBSCAN implementation
- Changed requirements and added optional requirements - nglview and matplotlib are NOT installed by default
- add options to visualise_pymol to stop pymol startup and reinitialization
- Quick version of MSRC was added which does not reset the clustering parameter scan after a good cluster is found
- fixed MSRC missing the outermost loop over the water types