### PR TITLE
Release v0.4.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,8 +23,8 @@ copyright = "2022, J Tosovic"
 author = "Jelena Tosovic, Domagoj Fijan, Marko Jukic, Urban Bren"
 
 # The full version, including alpha/beta/rc tags
-version = "0.3.0"
-release = "0.3.0"
+version = "0.4.0"
+release = "0.4.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ConservedWaterSearch"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     { name = "Domagoj Fijan" },
     { name = "Jelena Tosovic", email = "jecat_90@live.com" },


### PR DESCRIPTION
Release v0.4.0 - 04/09/2024
=================

Added
-------
- pre-commit support
- Theory section in the documentation has been added

Fixed
------
- Various improvements to documentation
- Fixed bug which prevent clustering on only oxygen data
- Fixed visualization bug for visualizing results of oxygen only clustering